### PR TITLE
VT-38

### DIFF
--- a/src/main/resources/db/migration/V21__user_avatar_constraint.sql
+++ b/src/main/resources/db/migration/V21__user_avatar_constraint.sql
@@ -1,0 +1,5 @@
+ALTER TABLE avatar DROP CONSTRAINT  avatar_users_id_fkey;
+
+ALTER TABLE avatar ADD CONSTRAINT  avatar_users_id_fkey FOREIGN KEY (users_id)
+REFERENCES users (id) MATCH SIMPLE
+            ON UPDATE NO ACTION ON DELETE CASCADE


### PR DESCRIPTION
I create new table in the database: V21__user_avatar_constraint.sql.
The table had a change from ON DELETE NO ACTION to ON DELETE CASCADE.
ON DELETE NO ACTION did not allow to delete the user by id due to the fact the user had an avatar. It was necessary first to delete the avatar and then to delete the user.
Bug fixed.

